### PR TITLE
Sorting migrations version

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -30,6 +30,6 @@ module MovieReview
     # config.i18n.default_locale = :de
 
     # Do not swallow errors in after_commit/after_rollback callbacks.
-    config.active_record.raise_in_transactional_callbacks = true
+    # config.active_record.raise_in_transactional_callbacks = true
   end
 end

--- a/db/migrate/20150406165142_create_movies.rb
+++ b/db/migrate/20150406165142_create_movies.rb
@@ -1,4 +1,4 @@
-class CreateMovies < ActiveRecord::Migration
+class CreateMovies < ActiveRecord::Migration[4.2]
   def change
     create_table :movies do |t|
       t.string :title

--- a/db/migrate/20150406181818_devise_create_users.rb
+++ b/db/migrate/20150406181818_devise_create_users.rb
@@ -1,4 +1,4 @@
-class DeviseCreateUsers < ActiveRecord::Migration
+class DeviseCreateUsers < ActiveRecord::Migration[4.2]
   def change
     create_table(:users) do |t|
       ## Database authenticatable

--- a/db/migrate/20150406182953_add_user_id_to_movies.rb
+++ b/db/migrate/20150406182953_add_user_id_to_movies.rb
@@ -1,4 +1,4 @@
-class AddUserIdToMovies < ActiveRecord::Migration
+class AddUserIdToMovies < ActiveRecord::Migration[4.2]
   def change
     add_column :movies, :user_id, :integer
   end

--- a/db/migrate/20150419210722_add_attachment_image_to_movies.rb
+++ b/db/migrate/20150419210722_add_attachment_image_to_movies.rb
@@ -1,4 +1,4 @@
-class AddAttachmentImageToMovies < ActiveRecord::Migration
+class AddAttachmentImageToMovies < ActiveRecord::Migration[4.2]
   def self.up
     change_table :movies do |t|
       t.attachment :image

--- a/db/migrate/20150929210106_create_reviews.rb
+++ b/db/migrate/20150929210106_create_reviews.rb
@@ -1,4 +1,4 @@
-class CreateReviews < ActiveRecord::Migration
+class CreateReviews < ActiveRecord::Migration[4.2]
   def change
     create_table :reviews do |t|
       t.integer :rating

--- a/db/migrate/20150929210911_add_user_id_to_reviews.rb
+++ b/db/migrate/20150929210911_add_user_id_to_reviews.rb
@@ -1,4 +1,4 @@
-class AddUserIdToReviews < ActiveRecord::Migration
+class AddUserIdToReviews < ActiveRecord::Migration[4.2]
   def change
     add_column :reviews, :user_id, :integer
   end

--- a/db/migrate/20150929212727_add_movie_id_to_reviews.rb
+++ b/db/migrate/20150929212727_add_movie_id_to_reviews.rb
@@ -1,4 +1,4 @@
-class AddMovieIdToReviews < ActiveRecord::Migration
+class AddMovieIdToReviews < ActiveRecord::Migration[4.2]
   def change
     add_column :reviews, :movie_id, :integer
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,50 +10,50 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150929212727) do
+ActiveRecord::Schema.define(version: 2015_09_29_212727) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
-  create_table "movies", force: :cascade do |t|
-    t.string   "title"
-    t.text     "description"
-    t.string   "movie_length"
-    t.string   "director"
-    t.string   "rating"
-    t.datetime "created_at",         null: false
-    t.datetime "updated_at",         null: false
-    t.integer  "user_id"
-    t.string   "image_file_name"
-    t.string   "image_content_type"
-    t.bigint   "image_file_size"
+  create_table "movies", id: :serial, force: :cascade do |t|
+    t.string "title"
+    t.text "description"
+    t.string "movie_length"
+    t.string "director"
+    t.string "rating"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "user_id"
+    t.string "image_file_name"
+    t.string "image_content_type"
+    t.bigint "image_file_size"
     t.datetime "image_updated_at"
   end
 
-  create_table "reviews", force: :cascade do |t|
-    t.integer  "rating"
-    t.text     "comment"
+  create_table "reviews", id: :serial, force: :cascade do |t|
+    t.integer "rating"
+    t.text "comment"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer  "user_id"
-    t.integer  "movie_id"
+    t.integer "user_id"
+    t.integer "movie_id"
   end
 
-  create_table "users", force: :cascade do |t|
-    t.string   "email",                  default: "", null: false
-    t.string   "encrypted_password",     default: "", null: false
-    t.string   "reset_password_token"
+  create_table "users", id: :serial, force: :cascade do |t|
+    t.string "email", default: "", null: false
+    t.string "encrypted_password", default: "", null: false
+    t.string "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
-    t.integer  "sign_in_count",          default: 0,  null: false
+    t.integer "sign_in_count", default: 0, null: false
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
-    t.inet     "current_sign_in_ip"
-    t.inet     "last_sign_in_ip"
+    t.inet "current_sign_in_ip"
+    t.inet "last_sign_in_ip"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.index ["email"], name: "index_users_on_email", unique: true, using: :btree
-    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
+    t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
 end


### PR DESCRIPTION
Setting migrations to the Rails versions they were generated from. In this app's case, they are set to [4.2] version.