### PR TITLE
Upgrading Nokogiro to version 1.11.5

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -121,7 +121,7 @@ GEM
       libv8-node (~> 15.14.0.0)
     minitest (5.14.4)
     nio4r (2.5.7)
-    nokogiri (1.11.3)
+    nokogiri (1.11.5)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
     orm_adapter (0.5.0)


### PR DESCRIPTION
**Bump nokogiri from 1.11.3 to 1.11.4**

**Remediation**

Upgrade nokogiri to version 1.11.4 or later. For example:

```ruby
gem "nokogiri", ">= 1.11.4"
```

**Details**

GHSA-7rrm-v45f-jp64
_moderate severity_
Vulnerable versions: < 1.11.4
Patched version: 1.11.4

**Summary**

Nokogiri v1.11.4 updates the vendored libxml2 from v2.9.10 to v2.9.12 which addresses:

    CVE-2019-20388 (Medium severity)
    CVE-2020-24977 (Medium severity)
    CVE-2021-3517 (Medium severity)
    CVE-2021-3518 (Medium severity)
    CVE-2021-3537 (Low severity)
    CVE-2021-3541 (Low severity)

Note that two additional CVEs were addressed upstream but are not relevant to this release. CVE-2021-3516 via xmllint is not present in Nokogiri, and CVE-2020-7595 has been patched in Nokogiri since v1.10.8 (see #1992).

Please note that this advisory only applies to the CRuby implementation of Nokogiri < 1.11.4, and only if the packaged version of libxml2 is being used. If you've overridden defaults at installation time to use system libraries instead of packaged libraries, you should instead pay attention to your distro's libxml2 release announcements.

**Mitigation**
```ruby
Upgrade to Nokogiri >= 1.11.4.
```

**Impact**

I've done a brief analysis of the published CVEs that are addressed in this upstream release. The libxml2 maintainers have not released a canonical set of CVEs, and so this list is pieced together from secondary sources and may be incomplete.

All information below is sourced from security.archlinux.org, which appears to have the most up-to-date information as of this analysis.

**[CVE-2019-20388](https://security.archlinux.org/CVE-2019-20388)**

    Severity: Medium
    Type: Denial of service
    Description: A memory leak was found in the xmlSchemaValidateStream function of libxml2. Applications that use this library may be vulnerable to memory not being freed leading to a denial of service.
    Fixed: https://gitlab.gnome.org/GNOME/libxml2/commit/7ffcd44d7e6c46704f8af0321d9314cd26e0e18a

Verified that the fix commit first appears in v2.9.11. It seems possible that this issue would be present in programs using Nokogiri < v1.11.4.

**CVE-2020-7595**

    Severity: Medium
    Type: Denial of service
    Description: xmlStringLenDecodeEntities in parser.c in libxml2 2.9.10 has an infinite loop in a certain end-of-file situation.
    Fixed: https://gitlab.gnome.org/GNOME/libxml2/commit/0e1a49c8907645d2e155f0d89d4d9895ac5112b5

This has been patched in Nokogiri since v1.10.8 (see #1992).

[**CVE-2020-24977**](https://security.archlinux.org/CVE-2020-24977)

    Severity: Medium
    Type: Information disclosure
    Description: GNOME project libxml2 <= 2.9.10 has a global buffer over-read vulnerability in xmlEncodeEntitiesInternal at libxml2/entities.c.
    Fixed: https://gitlab.gnome.org/GNOME/libxml2/commit/50f06b3efb638efb0abd95dc62dca05ae67882c2

Verified that the fix commit first appears in v2.9.11. It seems possible that this issue would be present in programs using Nokogiri < v1.11.4.

**[CVE-2021-3516](https://security.archlinux.org/CVE-2021-3516)**

    Severity: Medium
    Type: Arbitrary code execution (no remote vector)
    Description: A use-after-free security issue was found libxml2 before version 2.9.11 when "xmllint --html --push" is used to process crafted files.
    Issue: https://gitlab.gnome.org/GNOME/libxml2/-/issues/230
    Fixed: https://gitlab.gnome.org/GNOME/libxml2/-/commit/1358d157d0bd83be1dfe356a69213df9fac0b539

Verified that the fix commit first appears in v2.9.11. This vector does not exist within Nokogiri, which does not ship xmllint.

**[CVE-2021-3517](https://security.archlinux.org/CVE-2021-3517)**

    Severity: Medium
    Type: Arbitrary code execution
    Description: A heap-based buffer overflow was found in libxml2 before version 2.9.11 when processing truncated UTF-8 input.
    Issue: https://gitlab.gnome.org/GNOME/libxml2/-/issues/235
    Fixed: https://gitlab.gnome.org/GNOME/libxml2/-/commit/bf22713507fe1fc3a2c4b525cf0a88c2dc87a3a2

Verified that the fix commit first appears in v2.9.11. It seems possible that this issue would be present in programs using Nokogiri < v1.11.4.

**[CVE-2021-3518](https://security.archlinux.org/CVE-2021-3518)**

    Severity: Medium
    Type: Arbitrary code execution
    Description: A use-after-free security issue was found in libxml2 before version 2.9.11 in xmlXIncludeDoProcess() in xinclude.c when processing crafted files.
    Issue: https://gitlab.gnome.org/GNOME/libxml2/-/issues/237
    Fixed: https://gitlab.gnome.org/GNOME/libxml2/-/commit/1098c30a040e72a4654968547f415be4e4c40fe7

Verified that the fix commit first appears in v2.9.11. It seems possible that this issue would be present in programs using Nokogiri < v1.11.4.

**[CVE-2021-3537](https://security.archlinux.org/CVE-2021-3537)**

    Severity: Low
    Type: Denial of service
    Description: It was found that libxml2 before version 2.9.11 did not propagate errors while parsing XML mixed content, causing a NULL dereference. If an untrusted XML document was parsed in recovery mode and post-validated, the flaw could be used to crash the application.
    Issue: https://gitlab.gnome.org/GNOME/libxml2/-/issues/243
    Fixed: https://gitlab.gnome.org/GNOME/libxml2/-/commit/babe75030c7f64a37826bb3342317134568bef61

Verified that the fix commit first appears in v2.9.11. It seems possible that this issue would be present in programs using Nokogiri < v1.11.4.

**[CVE-2021-3541](https://security.archlinux.org/CVE-2021-3541)**

    Severity: Low
    Type: Denial of service
    Description: A security issue was found in libxml2 before version 2.9.11. Exponential entity expansion attack its possible bypassing all existing protection mechanisms and leading to denial of service.
    Fixed: https://gitlab.gnome.org/GNOME/libxml2/-/commit/8598060bacada41a0eb09d95c97744ff4e428f8e

Verified that the fix commit first appears in v2.9.11. It seems possible that this issue would be present in programs using Nokogiri < v1.11.4, however Nokogiri's default parse options prevent the attack from succeeding (it is necessary to opt into DTDLOAD which is off by default).

For more details supporting this analysis of this CVE, please visit #2233.
